### PR TITLE
必要な権限が足りなかった

### DIFF
--- a/.github/workflows/trigger-ai-review.yml
+++ b/.github/workflows/trigger-ai-review.yml
@@ -5,7 +5,9 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   check-team-member:


### PR DESCRIPTION
## 概要
ワークフロー実行後のコメントが記載するための権限が足りなかったので追記