### PR TITLE
Rails8系へのアップデートで削除してしまったメール設定を復旧

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,17 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
+  config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      enable_starttls_auto: true,
+       address: 'smtp.gmail.com',
+       port: 587,
+       domain: 'smtp.gmail.com',
+       user_name: Rails.application.credentials.gmail[:google_mail_address],
+       password: Rails.application.credentials.gmail[:google_mailer_password],
+       authentication: 'login'
+    }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
## 概要

メール設定を復旧させる

https://github.com/terumitt-dev/myblog/pull/36/files/0bdcb262cd49f977dc8d716792fb19b2a0572980#r2299449117
