### PR TITLE
MTデータをインポートできるようにする

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -52,10 +52,13 @@ class BlogsController < ApplicationController
   # POST /blogs/import_mt
   def import_mt
     if params[:file].present?
-      Blog.import_from_mt(params[:file])
-      redirect_to admin_root_path, notice: "MTデータをインポートしました"
+      Rails.logger.info "MT import started by Admin##{current_admin.id}"
+      count = Blog.import_from_mt(params[:file])
+      Rails.logger.info "MT import finished: #{count} entries created"
+
+      redirect_to admin_root_path, notice: t('controllers.common.notice_import', name: Blog.model_name.human, count: count)
     else
-      redirect_to admin_root_path, alert: "ファイルが選択されていません"
+      redirect_to admin_root_path, alert: t('controllers.common.alert_no_file')
     end
   end
 

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -2,6 +2,7 @@
 
 class BlogsController < ApplicationController
   before_action :set_blog, only: %i[show edit update destroy]
+   before_action :authenticate_admin!, only: [:import_mt]
 
   # GET /blogs or /blogs.json
   def index
@@ -46,6 +47,16 @@ class BlogsController < ApplicationController
   def destroy
     @blog.destroy
     redirect_to admin_root_url, notice: t('controllers.common.notice_destroy', name: Blog.model_name.human)
+  end
+
+  # POST /blogs/import_mt
+  def import_mt
+    if params[:file].present?
+      Blog.import_from_mt(params[:file])
+      redirect_to admin_root_path, notice: "MTデータをインポートしました"
+    else
+      redirect_to admin_root_path, alert: "ファイルが選択されていません"
+    end
   end
 
   private

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -20,15 +20,18 @@ class Blog < ApplicationRecord
   def self.parse_mt_content(content)
     entries = []
 
-    # 正規表現で記事単位を取得
     content.scan(
-      /TITLE:\s*(.+?)\r?\nBODY:\s*(.+?)(?:\r?\nDATE:\s*(.+?))?(?=\r?\nTITLE:|\z)/m
-    ) do |title, body, date|
+      /TITLE:\s*(.+?)\r?\nBODY:\s*(.+?)(?=\r?\nTITLE:|\z)/m
+    ) do |title, body|
+      title = title.gsub(/BASENAME:.*|STATUS:.*|ALLOW COMMENTS:.*|CONVERT BREAKS:.*|DATE:.*|IMAGE:.*|-----/i, '').strip
+
+      body = body.gsub(/^-{5,}(\s*-+)?(\s*AUTHOR:.*)?$/i, '')
+      body = body.strip
+
       entries << {
-        title: title.strip,
-        content: body.strip,
-        category: :uncategorized,
-        date: date ? (Time.parse(date.strip) rescue nil) : nil
+        title: title,
+        content: body,
+        category: :uncategorized
       }
     end
 

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -6,35 +6,53 @@ class Blog < ApplicationRecord
   enum :category, { uncategorized: 0, hobby: 1, tech: 2, other: 3 }, default: :uncategorized
 
   def self.import_from_mt(file)
-    content = File.read(file.path)
+    content = File.read(file.path, encoding: "UTF-8")
     entries = parse_mt_content(content)
-    entries.each do |entry|
-      Blog.create(
-        title: entry[:title],
-        content: entry[:content],
-        category: entry[:category] || :uncategorized
-      )
+
+    transaction do
+      entries.each do |entry|
+        date = parse_mt_date(entry[:date])
+        Blog.create!(
+          title: entry[:title],
+          content: entry[:content],
+          category: :uncategorized,
+          created_at: date
+        )
+      end
     end
+
+    entries.size
   end
 
   def self.parse_mt_content(content)
     entries = []
 
     content.scan(
-      /TITLE:\s*(.+?)\r?\nBODY:\s*(.+?)(?=\r?\nTITLE:|\z)/m
-    ) do |title, body|
-      title = title.gsub(/BASENAME:.*|STATUS:.*|ALLOW COMMENTS:.*|CONVERT BREAKS:.*|DATE:.*|IMAGE:.*|-----/i, '').strip
-
-      body = body.gsub(/^-{5,}(\s*-+)?(\s*AUTHOR:.*)?$/i, '')
-      body = body.strip
-
+      /AUTHOR:\s*(.+?)\r?\nTITLE:\s*(.+?)\r?\n(?:.*?\r?\n)*?DATE:\s*(.+?)\r?\n(?:.*?\r?\n)*?BODY:\r?\n(.+?)(?:\r?\n-----\r?\n)/m
+    ) do |_author, title, date, body|
       entries << {
-        title: title,
-        content: body,
-        category: :uncategorized
+        title: title.strip,
+        content: body.strip,
+        date: date.strip
       }
     end
 
     entries
+  end
+
+  def self.parse_mt_date(date_str)
+    return Time.zone.now if date_str.blank?
+
+    case date_str
+    when %r{\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}} # 12/17/2024 19:00:00
+      DateTime.strptime(date_str, "%m/%d/%Y %H:%M:%S")
+    when /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/   # 2023-06-04 22:57:15
+      DateTime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+    else
+      Time.zone.now
+    end
+  rescue => e
+    Rails.logger.warn "⚠️ DATE parse failed: #{date_str} (#{e.message})"
+    Time.zone.now
   end
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -20,18 +20,15 @@ class Blog < ApplicationRecord
   def self.parse_mt_content(content)
     entries = []
 
-    content.split("\n\n").each do |block|
-      title_match = block.match(/^TITLE:\s*(.*)$/i)
-      body_match  = block.match(/^BODY\s*:\s*(.*)$/im)
-      date_match  = block.match(/^DATE\s*:\s*(.*)$/i)
-
-      next unless title_match && body_match
-
+    # 正規表現で記事単位を取得
+    content.scan(
+      /TITLE:\s*(.+?)\r?\nBODY:\s*(.+?)(?:\r?\nDATE:\s*(.+?))?(?=\r?\nTITLE:|\z)/m
+    ) do |title, body, date|
       entries << {
-        title: title_match[1].strip,
-        content: body_match[1].strip,
+        title: title.strip,
+        content: body.strip,
         category: :uncategorized,
-        date: date_match ? (Time.parse(date_match[1].strip) rescue nil) : nil
+        date: date ? (Time.parse(date.strip) rescue nil) : nil
       }
     end
 

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -7,34 +7,34 @@ class Blog < ApplicationRecord
 
   def self.import_from_mt(file)
     content = File.read(file.path)
-    entries = parse_mt_content(content) # 独自解析メソッド
-
+    entries = parse_mt_content(content)
     entries.each do |entry|
-      create!(
+      Blog.create(
         title: entry[:title],
         content: entry[:content],
-        category: entry[:category] || :uncategorized,
-        created_at: entry[:date] || Time.current
+        category: entry[:category] || :uncategorized
       )
     end
   end
 
   def self.parse_mt_content(content)
     entries = []
+
     content.split("\n\n").each do |block|
-      title_match = block.match(/Title: (.*)/)
-      body_match  = block.match(/Body: (.*)/)
-      date_match  = block.match(/Date: (.*)/)
+      title_match = block.match(/^TITLE:\s*(.*)$/i)
+      body_match  = block.match(/^BODY\s*:\s*(.*)$/im)
+      date_match  = block.match(/^DATE\s*:\s*(.*)$/i)
 
       next unless title_match && body_match
 
       entries << {
-        title: title_match[1],
-        content: body_match[1],
+        title: title_match[1].strip,
+        content: body_match[1].strip,
         category: :uncategorized,
-        date: date_match&.to_time
+        date: date_match ? (Time.parse(date_match[1].strip) rescue nil) : nil
       }
     end
+
     entries
   end
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -4,4 +4,37 @@ class Blog < ApplicationRecord
   has_many :comments, dependent: :destroy
   validates :title, :category, :content, presence: true
   enum :category, { uncategorized: 0, hobby: 1, tech: 2, other: 3 }, default: :uncategorized
+
+  def self.import_from_mt(file)
+    content = File.read(file.path)
+    entries = parse_mt_content(content) # 独自解析メソッド
+
+    entries.each do |entry|
+      create!(
+        title: entry[:title],
+        content: entry[:content],
+        category: entry[:category] || :uncategorized,
+        created_at: entry[:date] || Time.current
+      )
+    end
+  end
+
+  def self.parse_mt_content(content)
+    entries = []
+    content.split("\n\n").each do |block|
+      title_match = block.match(/Title: (.*)/)
+      body_match  = block.match(/Body: (.*)/)
+      date_match  = block.match(/Date: (.*)/)
+
+      next unless title_match && body_match
+
+      entries << {
+        title: title_match[1],
+        content: body_match[1],
+        category: :uncategorized,
+        date: date_match&.to_time
+      }
+    end
+    entries
+  end
 end

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -2,6 +2,14 @@
   <h1 class="admin_title"><%= t('views.common.admins.admin_title', name: Admin.model_name.human) %></h1>
 </div>
 
+<div class="import">
+  <h2>MT形式データインポート</h2>
+    <%= form_with url: import_mt_blogs_path, local: true, multipart: true do |f| %>
+      <%= f.file_field :file, accept: ".txt,.mt" %>
+      <%= f.submit "インポート", class: "btn btn-primary" %>
+    <% end %>
+</div>
+
 <div class="admin_contents">
   <div class="admin_content">
     <div class="new_blogs_form">
@@ -27,12 +35,4 @@
       <%= button_to t('views.common.admins.logout', name: Admin.model_name.human.downcase), destroy_admin_session_path, method: :delete %>
     </div>
   </div>
-
-<h2>MT形式データインポート</h2>
-
-  <%= form_with url: import_mt_blogs_path, local: true, multipart: true do |f| %>
-    <%= f.file_field :file, accept: ".txt,.mt" %>
-    <%= f.submit "インポート", class: "btn btn-primary" %>
-  <% end %>
-
 </div>

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -27,4 +27,12 @@
       <%= button_to t('views.common.admins.logout', name: Admin.model_name.human.downcase), destroy_admin_session_path, method: :delete %>
     </div>
   </div>
+
+<h2>MT形式データインポート</h2>
+
+  <%= form_with url: import_mt_blogs_path, local: true, multipart: true do |f| %>
+    <%= f.file_field :file, accept: ".txt,.mt" %>
+    <%= f.submit "インポート", class: "btn btn-primary" %>
+  <% end %>
+
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,7 +17,7 @@ ja:
       admins:
         admin_title: "%{name}ページ"
         logout: "%{name}ログアウト"
-    
+
       blogs:
         blog_name: "ブログタイトル（未定）"
         login: "%{name}ログイン"
@@ -36,11 +36,13 @@ ja:
       notice_update: "%{name}が更新されました。"
       notice_destroy: "%{name}が削除されました。"
       alert_create: "%{name}が作成できませんでした。"
+      notice_import: "%{name}をインポートしました（%{count}件）"
+      alert_no_file: "ファイルが選択されていません"
 
   helpers:
     submit:
       create: 記録する
-      update: 更新する 
+      update: 更新する
 
   shared:
     links:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,12 @@ Rails.application.routes.draw do
 
   authenticated :admin do
     get 'admin', to: 'admins#index', as: :admin_root
-    resources :blogs
+    # resources :blogs
+    resources :blogs do
+        collection do
+          post :import_mt   # MT形式インポート用
+        end
+      end
   end
 
   resources :blogs, only: %i[index show] do

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -33,4 +33,36 @@ RSpec.describe Blog, type: :model do
       end
     end
   end
+
+  describe '.import_from_mt' do
+    it '正しいMTファイルでブログが作成されること' do
+      temp_file = Tempfile.new(['sample', '.mt'])
+      temp_file.write("AUTHOR: test\nTITLE: サンプルブログ\nDATE: 12/17/2024 19:00:00\nBODY:\n本文です\n-----\n")
+      temp_file.rewind
+
+      expect {
+        Blog.import_from_mt(temp_file)
+      }.to change(Blog, :count).by(1)
+
+      blog = Blog.last
+      expect(blog.title).to eq 'サンプルブログ'
+      expect(blog.content).to eq '本文です'
+
+      temp_file.close
+      temp_file.unlink
+    end
+
+    it '無効なMTファイルではブログが作成されないこと' do
+      temp_file = Tempfile.new(['invalid', '.txt'])
+      temp_file.write("無効な内容")
+      temp_file.rewind
+
+      expect {
+        Blog.import_from_mt(temp_file)
+      }.to_not change(Blog, :count)
+
+      temp_file.close
+      temp_file.unlink
+    end
+  end
 end


### PR DESCRIPTION
## 概要
はてなブログからmyblogにMTデータをインポートして投稿していたデータの移行ができるようにする
