### PR TITLE
fix: Drone CIをDinD方式に変更

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,6 +40,7 @@ steps:
       ECR_REGISTRY:
         from_secret: ECR_REGISTRY
     commands:
+      - set -euo pipefail
       - echo "🐳 Starting Docker daemon..."
       - dockerd-entrypoint.sh &
       - |

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,19 +19,17 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       ECR_REGISTRY:
         from_secret: ECR_REGISTRY
-      WORKER_INSTANCE_ID:
-        from_secret: WORKER_INSTANCE_ID
     commands:
       - set -euo pipefail
       - '[ -n "$AWS_REGION" ] || (echo "❌ AWS_REGION is not set" && exit 1)'
       - '[ -n "$AWS_ACCESS_KEY_ID" ] || (echo "❌ AWS_ACCESS_KEY_ID is not set" && exit 1)'
       - '[ -n "$AWS_SECRET_ACCESS_KEY" ] || (echo "❌ AWS_SECRET_ACCESS_KEY is not set" && exit 1)'
       - '[ -n "$ECR_REGISTRY" ] || (echo "❌ ECR_REGISTRY is not set" && exit 1)'
-      - '[ -n "$WORKER_INSTANCE_ID" ] || (echo "❌ WORKER_INSTANCE_ID is not set" && exit 1)'
       - echo "✅ All required variables are set"
 
-  - name: build-and-push-via-ssm
-    image: amazon/aws-cli:latest
+  - name: build-and-push
+    image: docker:24-dind
+    privileged: true
     environment:
       AWS_REGION:
         from_secret: AWS_REGION
@@ -41,62 +39,27 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       ECR_REGISTRY:
         from_secret: ECR_REGISTRY
-      WORKER_INSTANCE_ID:
-        from_secret: WORKER_INSTANCE_ID
     commands:
-      - echo "🔨 Building and pushing Docker image via SSM..."
-      - aws configure set region "$AWS_REGION"
-      - aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
-      - aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
-
+      - echo "🐳 Starting Docker daemon..."
+      - dockerd-entrypoint.sh &
       - |
-        COMMIT_SHA=${DRONE_COMMIT_SHA}
-        REPO_URL="https://github.com/${DRONE_REPO}.git"
-        IMAGE_NAME="$ECR_REGISTRY/go-lilaregard-backend"
-
-        COMMAND_ID=$(aws ssm send-command \
-          --instance-ids "$WORKER_INSTANCE_ID" \
-          --document-name "AWS-RunShellScript" \
-          --timeout-seconds 600 \
-          --parameters "{\"commands\":[
-            \"set -e\",
-            \"echo '🔐 Logging in to ECR...'\",
-            \"aws ecr get-login-password --region $AWS_REGION | sudo docker login --username AWS --password-stdin $ECR_REGISTRY\",
-            \"echo '📥 Cloning repository...'\",
-            \"cd /tmp && rm -rf myblog-backend && git clone $REPO_URL myblog-backend && cd myblog-backend && git checkout $COMMIT_SHA\",
-            \"echo '🔨 Building Docker image...'\",
-            \"sudo docker build -f Dockerfile.prod -t $IMAGE_NAME:$COMMIT_SHA -t $IMAGE_NAME:latest .\",
-            \"echo '🚀 Pushing to ECR...'\",
-            \"sudo docker push $IMAGE_NAME:$COMMIT_SHA\",
-            \"sudo docker push $IMAGE_NAME:latest\",
-            \"echo '🧹 Cleaning up...'\",
-            \"cd /tmp && rm -rf myblog-backend\",
-            \"sudo docker image prune -f\",
-            \"echo '✅ Image pushed successfully: $IMAGE_NAME:$COMMIT_SHA'\"
-          ]}" \
-          --query 'Command.CommandId' --output text)
-
-        echo "Command ID: $COMMAND_ID"
-
-        echo "⏳ Waiting for build to complete..."
-        for i in $(seq 1 120); do
-          STATUS=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$WORKER_INSTANCE_ID" \
-            --query 'Status' --output text 2>/dev/null || echo "Pending")
-
-          if [ "$STATUS" = "Success" ]; then
-            echo "✅ Build and push completed successfully"
-            aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$WORKER_INSTANCE_ID" --query 'StandardOutputContent' --output text
-            exit 0
-          elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
-            echo "❌ Build failed with status: $STATUS"
-            aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$WORKER_INSTANCE_ID" --query 'StandardErrorContent' --output text
-            exit 1
-          fi
-
-          sleep 5
+        for i in $(seq 1 60); do
+          if docker info >/dev/null 2>&1; then break; fi
+          echo "Waiting for Docker..."
+          sleep 1
+          if [ "$i" -eq 60 ]; then echo "❌ Docker daemon failed to start"; exit 1; fi
         done
 
-        echo "❌ Build timed out after 10 minutes"
-        exit 1
+      - echo "🔐 Logging in to ECR..."
+      - apk add --no-cache aws-cli
+      - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
+
+      - echo "🔨 Building Docker image..."
+      - docker build -f Dockerfile.prod -t $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA} -t $ECR_REGISTRY/go-lilaregard-backend:latest .
+
+      - echo "🚀 Pushing to ECR..."
+      - docker push $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA}
+      - docker push $ECR_REGISTRY/go-lilaregard-backend:latest
+
+      - echo "✅ Image pushed successfully"
+      - echo "   → $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA}"

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ type: docker
 name: build-and-push
 
 trigger:
-  branch: [main]
+  branch: [main, develop]
   event: [push]
 
 steps:
@@ -27,7 +27,26 @@ steps:
       - '[ -n "$ECR_REGISTRY" ] || (echo "❌ ECR_REGISTRY is not set" && exit 1)'
       - echo "✅ All required variables are set"
 
-  - name: build-and-push
+  - name: build
+    image: docker:24-dind
+    privileged: true
+    commands:
+      - set -euo pipefail
+      - echo "🐳 Starting Docker daemon..."
+      - dockerd-entrypoint.sh &
+      - |
+        for i in $(seq 1 60); do
+          if docker info >/dev/null 2>&1; then break; fi
+          echo "Waiting for Docker..."
+          sleep 1
+          if [ "$i" -eq 60 ]; then echo "❌ Docker daemon failed to start"; exit 1; fi
+        done
+
+      - echo "🔨 Building Docker image (dry-run)..."
+      - docker build -f Dockerfile.prod -t go-lilaregard-backend:${DRONE_COMMIT_SHA} .
+      - echo "✅ Build succeeded"
+
+  - name: push-to-ecr
     image: docker:24-dind
     privileged: true
     environment:
@@ -64,3 +83,5 @@ steps:
 
       - echo "✅ Image pushed successfully"
       - echo "   → $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA}"
+    when:
+      branch: [main]


### PR DESCRIPTION
## Summary
- SSM経由ビルドではWorker EC2にDockerが未インストールのため失敗
- DinD（docker:24-dind + privileged）方式に変更し、Drone CI内で完結
- Trustedリポジトリ設定を有効化済み

## Test plan
- [ ] mainにマージ後、Drone CIがトリガーされECRにイメージがpushされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)