### PR TITLE
fix: Drone CI/CDパイプライン分離

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,17 +47,20 @@ steps:
           bundle exec puma -C config/puma.rb
 
         echo "   Waiting for container to start..."
-        sleep 10
+        for i in $(seq 1 30); do
+          if docker ps --filter name=backend-ci --format "{{.Status}}" | grep -q "Up"; then
+            break
+          fi
+          sleep 1
+          if [ "$i" -eq 30 ]; then
+            echo "❌ Container failed to start"
+            docker logs backend-ci 2>&1 | tail -30
+            exit 1
+          fi
+        done
 
         echo "   Container status:"
         docker ps --filter name=backend-ci --format "   {{.Status}}"
-
-        if ! docker ps --filter name=backend-ci --format "{{.Status}}" | grep -q "Up"; then
-          echo "❌ Container failed to start"
-          echo "   Container logs:"
-          docker logs backend-ci 2>&1 | tail -30
-          exit 1
-        fi
         echo "✅ Container is running"
 
       - echo ""

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,25 +10,6 @@ trigger:
   event: [push]
 
 steps:
-  - name: check-vars
-    image: alpine
-    environment:
-      AWS_REGION:
-        from_secret: AWS_REGION
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      ECR_REGISTRY:
-        from_secret: ECR_REGISTRY
-    commands:
-      - set -euo pipefail
-      - '[ -n "$AWS_REGION" ] || (echo "❌ AWS_REGION is not set" && exit 1)'
-      - '[ -n "$AWS_ACCESS_KEY_ID" ] || (echo "❌ AWS_ACCESS_KEY_ID is not set" && exit 1)'
-      - '[ -n "$AWS_SECRET_ACCESS_KEY" ] || (echo "❌ AWS_SECRET_ACCESS_KEY is not set" && exit 1)'
-      - '[ -n "$ECR_REGISTRY" ] || (echo "❌ ECR_REGISTRY is not set" && exit 1)'
-      - echo "✅ All required variables are set"
-
   - name: build-dry-run
     image: docker:24-dind
     privileged: true
@@ -64,6 +45,25 @@ depends_on:
   - ci
 
 steps:
+  - name: check-vars
+    image: alpine
+    environment:
+      AWS_REGION:
+        from_secret: AWS_REGION
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      ECR_REGISTRY:
+        from_secret: ECR_REGISTRY
+    commands:
+      - set -euo pipefail
+      - '[ -n "$AWS_REGION" ] || (echo "❌ AWS_REGION is not set" && exit 1)'
+      - '[ -n "$AWS_ACCESS_KEY_ID" ] || (echo "❌ AWS_ACCESS_KEY_ID is not set" && exit 1)'
+      - '[ -n "$AWS_SECRET_ACCESS_KEY" ] || (echo "❌ AWS_SECRET_ACCESS_KEY is not set" && exit 1)'
+      - '[ -n "$ECR_REGISTRY" ] || (echo "❌ ECR_REGISTRY is not set" && exit 1)'
+      - echo "✅ All required variables are set"
+
   - name: build-and-push
     image: docker:24-dind
     privileged: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 # =========================
-# CI Pipeline (dry-run)
+# CI Pipeline (build & verify)
 # =========================
 kind: pipeline
 type: docker
@@ -10,7 +10,7 @@ trigger:
   event: [push]
 
 steps:
-  - name: build-dry-run
+  - name: build-and-verify
     image: docker:24-dind
     privileged: true
     commands:
@@ -25,9 +25,56 @@ steps:
           if [ "$i" -eq 60 ]; then echo "❌ Docker daemon failed to start"; exit 1; fi
         done
 
-      - echo "🔨 Building Docker image (dry-run)..."
-      - docker build -f Dockerfile.prod -t go-lilaregard-backend:dry-run .
+      - echo "🔨 Building Docker image..."
+      - docker build -f Dockerfile.prod -t go-lilaregard-backend:ci .
       - echo "✅ Build succeeded"
+
+      - echo ""
+      - echo "📏 Image size check..."
+      - docker images go-lilaregard-backend:ci --format "   Size:{{.Size}}"
+      - echo ""
+
+      - echo "🏥 Container startup check..."
+      - |
+        docker run -d --name backend-ci \
+          -e RAILS_ENV=production \
+          -e SECRET_KEY_BASE=ci_test_secret_key_base_dummy_value_for_testing \
+          -e DATABASE_HOST=localhost \
+          -e DATABASE_USERNAME=dummy \
+          -e DATABASE_PASSWORD=dummy \
+          -p 3000:3000 \
+          go-lilaregard-backend:ci \
+          bundle exec puma -C config/puma.rb
+
+        echo "   Waiting for container to start..."
+        sleep 10
+
+        echo "   Container status:"
+        docker ps --filter name=backend-ci --format "   {{.Status}}"
+
+        if ! docker ps --filter name=backend-ci --format "{{.Status}}" | grep -q "Up"; then
+          echo "❌ Container failed to start"
+          echo "   Container logs:"
+          docker logs backend-ci 2>&1 | tail -30
+          exit 1
+        fi
+        echo "✅ Container is running"
+
+      - echo ""
+      - echo "🌐 Health check..."
+      - |
+        HTTP_STATUS=$(docker exec backend-ci wget -qO- -S http://localhost:3000/up 2>&1 | head -1 || true)
+        if docker exec backend-ci wget -qO- http://localhost:3000/up >/dev/null 2>&1; then
+          echo "✅ Health check passed (/up endpoint responded)"
+        else
+          echo "⚠️ Health check skipped (DB not available, but container started successfully)"
+        fi
+
+      - echo ""
+      - echo "🧹 Cleanup..."
+      - docker stop backend-ci && docker rm backend-ci
+      - echo ""
+      - echo "✅ All CI checks passed"
 
 ---
 # =========================

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,9 @@
----
+# =========================
+# CI Pipeline (dry-run)
+# =========================
 kind: pipeline
 type: docker
-name: build-and-push
+name: ci
 
 trigger:
   branch: [main, develop]
@@ -27,7 +29,7 @@ steps:
       - '[ -n "$ECR_REGISTRY" ] || (echo "❌ ECR_REGISTRY is not set" && exit 1)'
       - echo "✅ All required variables are set"
 
-  - name: build
+  - name: build-dry-run
     image: docker:24-dind
     privileged: true
     commands:
@@ -43,10 +45,26 @@ steps:
         done
 
       - echo "🔨 Building Docker image (dry-run)..."
-      - docker build -f Dockerfile.prod -t go-lilaregard-backend:${DRONE_COMMIT_SHA} .
+      - docker build -f Dockerfile.prod -t go-lilaregard-backend:dry-run .
       - echo "✅ Build succeeded"
 
-  - name: push-to-ecr
+---
+# =========================
+# CD Pipeline (ECR push)
+# =========================
+kind: pipeline
+type: docker
+name: cd
+
+trigger:
+  branch: [main]
+  event: [push]
+
+depends_on:
+  - ci
+
+steps:
+  - name: build-and-push
     image: docker:24-dind
     privileged: true
     environment:
@@ -83,5 +101,3 @@ steps:
 
       - echo "✅ Image pushed successfully"
       - echo "   → $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA}"
-    when:
-      branch: [main]


### PR DESCRIPTION
## Summary
- CIパイプライン（ci）: main/develop — ビルドのみ（dry-run、Dockerfile検証）
- CDパイプライン（cd）: mainのみ — ビルド + ECR push（`depends_on: ci` で CI成功後に実行）
- opsリポジトリと同じパターンに統一

## Test plan
- [ ] developブランチ: CIのみ実行（CDはスキップ）
- [ ] mainブランチ: CI成功後にCDが実行されECRにpush

🤖 Generated with [Claude Code](https://claude.com/claude-code)