### PR TITLE
fix: Dockerイメージビルドエラーを修正

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -20,14 +20,7 @@ RUN bundle install --jobs 4
 
 COPY . .
 
-# アセットプリコンパイル（sprockets-rails用、ダミーSECRET_KEY_BASE）
-ENV RAILS_ENV=production \
-    SECRET_KEY_BASE=dummy_for_precompilation
-RUN DATABASE_HOST=dummy \
-    DATABASE_NAME=dummy \
-    DATABASE_USERNAME=dummy \
-    DATABASE_PASSWORD=dummy \
-    bundle exec rails assets:precompile
+ENV RAILS_ENV=production
 
 # ============================================
 # Stage 2: Runtime


### PR DESCRIPTION
## Summary
- API-onlyアプリのためassets:precompileを削除（Rails環境ロード時のDB接続エラーを回避）

## Test plan
- [ ] CIのDockerイメージビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)