### PR TITLE
feat: database.ymlにDATABASE_PORT環境変数対応

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   host: <%= ENV.fetch("DATABASE_HOST", "db") %>
-  port: <%= ENV.fetch("DATABASE_PORT", "5432") %>
+  port: <%= ENV.fetch("DATABASE_PORT", "5432").to_i %>
   username: <%= ENV.fetch("DATABASE_USERNAME", "postgres") %>
   password: <%= ENV.fetch("DATABASE_PASSWORD", "password") %>
   # For details on connection pooling, see Rails configuration guide

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,6 +18,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   host: <%= ENV.fetch("DATABASE_HOST", "db") %>
+  port: <%= ENV.fetch("DATABASE_PORT", "5432") %>
   username: <%= ENV.fetch("DATABASE_USERNAME", "postgres") %>
   password: <%= ENV.fetch("DATABASE_PASSWORD", "password") %>
   # For details on connection pooling, see Rails configuration guide


### PR DESCRIPTION
## Summary
- database.ymlにDATABASE_PORT環境変数を追加（デフォルト: 5432）
- 本番K8sではPostgreSQLのポートを95432に変更するため

## Test plan
- [ ] ローカル開発環境に影響なし（デフォルト5432）

🤖 Generated with [Claude Code](https://claude.com/claude-code)