### PR TITLE
feat: K8sヘルスチェック用の/upエンドポイント追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # K8s liveness/readiness probe用ヘルスチェック
+  get 'up' => 'rails/health#show', as: :rails_health_check
+
   devise_for :admins, skip: [:sessions, :registrations]
 
   namespace :api do


### PR DESCRIPTION
## Summary
- K8s liveness/readiness probeで使用する`/up`エンドポイントを追加
- Rails 7.1+標準の`Rails::HealthController`を利用

## 背景
go-lilaregard-opsの`backend-deployment.yaml`でprobeパスが`/up`に設定されているが、現在のRails appに該当ルートが存在せず404が返り、Backend Podがreadyにならない状態。

## 変更
`config/routes.rb`に1行追加:
```ruby
get 'up' => 'rails/health#show', as: :rails_health_check
```

## Test plan
- [ ] CIパスする
- [ ] デプロイ後、`curl http://backend:8080/up` で200が返る
- [ ] Backend PodがReady(1/1)になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)