### PR TITLE
fix: aws-cli インストールをexpatアップグレード方式に変更

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,10 +91,11 @@ steps:
         if [ "${DRONE_BUILD_EVENT}" = "push" ] && [ "${DRONE_BRANCH}" = "main" ]; then
           echo ""
           echo "🔐 Logging in to ECR..."
-          # Alpineのaws-cliパッケージはlibexpat ABI mismatchで壊れているため
-          # pip経由でインストールする
-          apk add --no-cache python3 py3-pip
-          pip3 install --break-system-packages awscli
+          # libexpatのABI mismatch対策で先にexpatをアップグレード
+          # （pip経由でも同じpyexpat ABI問題で失敗するため）
+          apk update
+          apk upgrade --no-cache expat
+          apk add --no-cache aws-cli
           aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
 
           echo "🏷️ Tagging image for ECR..."


### PR DESCRIPTION
## Summary
前回のpip経由インストールも libexpat ABI mismatch で失敗していたため、別アプローチに変更。

## エラー
\`\`\`
pip3 install ...
ImportError: Error relocating /usr/lib/python3.12/lib-dynload/pyexpat.cpython-312-x86_64-linux-musl.so:
  XML_SetAllocTrackerActivationThreshold: symbol not found
\`\`\`

pip自体がpyexpatに依存しているため、pip経由でも同じエラーになる。

## 修正
\`apk upgrade expat\` で先にlibexpatをアップグレードしてから \`apk add aws-cli\` を実行。

## Test plan
- [ ] CDでECRログイン成功
- [ ] イメージpush成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)