### PR TITLE
feat: Cache-Controlヘッダーを明示的に設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ jwt_blacklists
   → JWT を jwt_blacklists テーブルに登録（以降無効化）
 ```
 
+## キャッシュ戦略
+
+全エンドポイントで `Cache-Control` ヘッダーを明示的に制御し、CDN（Cloudflare 等）の意図しないキャッシュ事故を防いでいます。
+
+### 戦略
+
+| エンドポイント | Cache-Control | 目的 |
+|---|---|---|
+| `GET /api/blogs` | `public, s-maxage=300, max-age=0` | CDN は5分キャッシュ、ブラウザは毎回確認 |
+| `GET /api/blogs/:id` | 同上 | 同上 |
+| `GET /api/blogs/:id/comments` | 同上 | 同上 |
+| 上記以外（認証・変更・管理系） | `no-store` | 一切キャッシュしない |
+
+### 設計の意図
+
+- **デフォルト `no-store`**: `ApplicationController#set_default_cache_control` で全エンドポイントに適用。新しい API 追加時の事故を防ぐ安全側設計。
+- **パブリック GET のみ明示的に上書き**: `set_cdn_cacheable` を `before_action` で指定する形で許可。
+- **`s-maxage=300 + max-age=0` の組み合わせ**: CDN には5分間キャッシュを許可しつつ、ブラウザにはキャッシュさせない。記事更新時、最大5分で全ユーザーに反映。
+- **CDN 非依存**: `Cache-Control` は HTTP 標準ヘッダーなので、Cloudflare / CloudFront / Fastly など CDN を切り替えても同じ戦略が機能する。
+
 ## セキュリティ
 
 | 対策 | 実装 |

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ jwt_blacklists
 ### 設計の意図
 
 - **デフォルト `no-store`**: `ApplicationController#set_default_cache_control` で全エンドポイントに適用。新しい API 追加時の事故を防ぐ安全側設計。
-- **パブリック GET のみ明示的に上書き**: `set_cdn_cacheable` を `before_action` で指定する形で許可。
+- **パブリック GET のみ明示的に上書き**: `set_cdn_cacheable` を `before_action` で指定する形で許可フラグを立てる。
+- **`after_action` で実際のヘッダーを付与**: エラー応答（4xx/5xx）や認証付きリクエストをキャッシュ対象から除外。成功した匿名 GET のみ `public` として扱う。
+- **`Vary: Authorization, Cookie`**: 認証情報ごとに別キャッシュエントリとして扱われるため、個人化レスポンスの共有キャッシュ混入を防止。
 - **`s-maxage=300 + max-age=0` の組み合わせ**: CDN には5分間キャッシュを許可しつつ、ブラウザにはキャッシュさせない。記事更新時、最大5分で全ユーザーに反映。
 - **CDN 非依存**: `Cache-Control` は HTTP 標準ヘッダーなので、Cloudflare / CloudFront / Fastly など CDN を切り替えても同じ戦略が機能する。
 

--- a/app/controllers/api/blogs_controller.rb
+++ b/app/controllers/api/blogs_controller.rb
@@ -3,7 +3,6 @@
 module Api
   class BlogsController < ApplicationController
     before_action :set_blog, only: [:show]
-    # CDN（Cloudflare等）に5分キャッシュさせるが、ブラウザはキャッシュしない
     before_action :set_cdn_cacheable, only: [:index, :show]
 
     # GET /api/blogs

--- a/app/controllers/api/blogs_controller.rb
+++ b/app/controllers/api/blogs_controller.rb
@@ -3,6 +3,8 @@
 module Api
   class BlogsController < ApplicationController
     before_action :set_blog, only: [:show]
+    # CDN（Cloudflare等）に5分キャッシュさせるが、ブラウザはキャッシュしない
+    before_action :set_cdn_cacheable, only: [:index, :show]
 
     # GET /api/blogs
     def index
@@ -69,6 +71,12 @@ module Api
       @blog = Blog.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       render json: { error: 'Blog not found' }, status: :not_found and return
+    end
+
+    # s-maxage: CDNのキャッシュ期間（5分）
+    # max-age=0: ブラウザはキャッシュしない（常にCDNに問い合わせる）
+    def set_cdn_cacheable
+      response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
     end
   end
 end

--- a/app/controllers/api/blogs_controller.rb
+++ b/app/controllers/api/blogs_controller.rb
@@ -72,11 +72,5 @@ module Api
     rescue ActiveRecord::RecordNotFound
       render json: { error: 'Blog not found' }, status: :not_found and return
     end
-
-    # s-maxage: CDNのキャッシュ期間（5分）
-    # max-age=0: ブラウザはキャッシュしない（常にCDNに問い合わせる）
-    def set_cdn_cacheable
-      response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
-    end
   end
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -55,9 +55,5 @@ module Api
     def comment_params
       params.require(:comment).permit(:user_name, :comment)
     end
-
-    def set_cdn_cacheable
-      response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
-    end
   end
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -3,6 +3,7 @@
 module Api
   class CommentsController < ApplicationController
     before_action :set_blog
+    before_action :set_cdn_cacheable, only: [:index]
 
     # GET /api/blogs/:blog_id/comments
     def index
@@ -53,6 +54,10 @@ module Api
 
     def comment_params
       params.require(:comment).permit(:user_name, :comment)
+    end
+
+    def set_cdn_cacheable
+      response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::API
 
   before_action :set_locale
   before_action :set_default_cache_control
+  after_action :apply_pending_cache_control
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
   rescue_from ActionController::ParameterMissing, with: :parameter_missing
@@ -17,15 +18,30 @@ class ApplicationController < ActionController::API
   end
 
   # デフォルトはキャッシュ禁止（認証・変更系エンドポイント向け）
-  # パブリック GET はコントローラー側で set_cdn_cacheable を呼んで上書きする
+  # パブリック GET はコントローラー側で set_cdn_cacheable を呼んで許可フラグを立てる
   def set_default_cache_control
     response.headers['Cache-Control'] = 'no-store'
   end
 
-  # CDN（Cloudflare等）に5分キャッシュさせるが、ブラウザはキャッシュしない
   # パブリック GET エンドポイントで before_action から呼び出す
+  # 実際の Cache-Control 設定は after_action で成功時のみ行う（誤キャッシュ防止）
   def set_cdn_cacheable
+    request.env['cdn_cacheable'] = true
+  end
+
+  # CDN（Cloudflare等）に5分キャッシュさせるが、ブラウザはキャッシュしない。
+  # 以下の条件を全て満たす場合のみ適用：
+  # - set_cdn_cacheable でフラグが立っている
+  # - GET リクエスト
+  # - レスポンスが 2xx（404/422 等のエラーレスポンスをキャッシュさせない）
+  # - 認証情報（Authorization / Cookie）がない（個人化レスポンスを共有キャッシュさせない）
+  def apply_pending_cache_control
+    return unless request.env['cdn_cacheable']
+    return unless request.get? && response.successful?
+    return if request.authorization.present? || request.headers['Cookie'].present?
+
     response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
+    response.headers['Vary'] = 'Authorization, Cookie'
   end
 
   def record_not_found(exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::API
   include Devise::Controllers::Helpers
 
   before_action :set_locale
+  before_action :set_default_cache_control
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
   rescue_from ActionController::ParameterMissing, with: :parameter_missing
@@ -13,6 +14,12 @@ class ApplicationController < ActionController::API
 
   def set_locale
     I18n.locale = :ja
+  end
+
+  # デフォルトはキャッシュ禁止（認証・変更系エンドポイント向け）
+  # パブリック GET はコントローラー側で上書きする
+  def set_default_cache_control
+    response.headers['Cache-Control'] = 'no-store'
   end
 
   def record_not_found(exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,9 +17,15 @@ class ApplicationController < ActionController::API
   end
 
   # デフォルトはキャッシュ禁止（認証・変更系エンドポイント向け）
-  # パブリック GET はコントローラー側で上書きする
+  # パブリック GET はコントローラー側で set_cdn_cacheable を呼んで上書きする
   def set_default_cache_control
     response.headers['Cache-Control'] = 'no-store'
+  end
+
+  # CDN（Cloudflare等）に5分キャッシュさせるが、ブラウザはキャッシュしない
+  # パブリック GET エンドポイントで before_action から呼び出す
+  def set_cdn_cacheable
+    response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
   end
 
   def record_not_found(exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,11 +35,14 @@ class ApplicationController < ActionController::API
   # - GET リクエスト
   # - レスポンスが 2xx または 304（404/422 等のエラーレスポンスをキャッシュさせない）
   # - 認証情報（Authorization / Cookie）がない（個人化レスポンスを共有キャッシュさせない）
+  # - レスポンスに Set-Cookie がない（個別状態を共有キャッシュに保存させない）
   def apply_pending_cache_control
     return unless request.env['cdn_cacheable']
     return unless request.get?
     return unless response.successful? || response.status == 304
-    return if request.authorization.present? || request.headers['Cookie'].present?
+    return if request.authorization.present? ||
+              request.headers['Cookie'].present? ||
+              response.headers['Set-Cookie'].present?
 
     response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
     # 既存の Vary を保持しつつ Authorization と Cookie を追加（他middlewareとの共存）

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,15 +33,18 @@ class ApplicationController < ActionController::API
   # 以下の条件を全て満たす場合のみ適用：
   # - set_cdn_cacheable でフラグが立っている
   # - GET リクエスト
-  # - レスポンスが 2xx（404/422 等のエラーレスポンスをキャッシュさせない）
+  # - レスポンスが 2xx または 304（404/422 等のエラーレスポンスをキャッシュさせない）
   # - 認証情報（Authorization / Cookie）がない（個人化レスポンスを共有キャッシュさせない）
   def apply_pending_cache_control
     return unless request.env['cdn_cacheable']
-    return unless request.get? && response.successful?
+    return unless request.get?
+    return unless response.successful? || response.status == 304
     return if request.authorization.present? || request.headers['Cookie'].present?
 
     response.headers['Cache-Control'] = 'public, s-maxage=300, max-age=0'
-    response.headers['Vary'] = 'Authorization, Cookie'
+    # 既存の Vary を保持しつつ Authorization と Cookie を追加（他middlewareとの共存）
+    vary_values = response.headers['Vary'].to_s.split(',').map(&:strip)
+    response.headers['Vary'] = (vary_values + ['Authorization', 'Cookie']).reject(&:empty?).uniq.join(', ')
   end
 
   def record_not_found(exception)


### PR DESCRIPTION
## Summary
- 全エンドポイントにデフォルト `no-store` を設定
- パブリック GET のみ `public, s-maxage=300, max-age=0` で CDN キャッシュを許可

## 背景
Cloudflare が API レスポンスを独自判断でキャッシュし、空の記事一覧が返り続ける事故が発生した。
backend 側で Cache-Control を明示的に制御することで、CDN サービスに依存せずキャッシュ戦略をコードで管理する。

## キャッシュ戦略

| エンドポイント | Cache-Control | 理由 |
|---|---|---|
| `GET /api/blogs` | `public, s-maxage=300, max-age=0` | CDN 5分キャッシュ、ブラウザはキャッシュしない |
| `GET /api/blogs/:id` | 同上 | 同上 |
| `GET /api/comments` | 同上 | 同上 |
| その他全て | `no-store` | 認証・変更系は一切キャッシュしない |

- `s-maxage=300`: CDN（Cloudflare等）が5分間キャッシュを保持
- `max-age=0`: ブラウザはキャッシュせず常にCDNに問い合わせ
- `no-store`: キャッシュ完全禁止（認証トークン等の漏洩防止）

## Test plan
- [ ] Drone CIがグリーンになること
- [ ] `curl -I https://go-lilaregard.com/api/blogs` で `cache-control: public, s-maxage=300, max-age=0` が返ること
- [ ] `curl -I https://go-lilaregard.com/api/auth/current_user` で `cache-control: no-store` が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)