### PR TITLE
feat: コメントフォームに Cloudflare Turnstile 検証を追加

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -2,8 +2,14 @@
 
 module Api
   class CommentsController < ApplicationController
-    before_action :set_blog
+    # create のみ verify_turnstile! を set_blog より先に走らせる。
+    # bot による無効 token + 任意 blog_id のスパムで DB 参照を発生させない目的:
+    # - DB 負荷の抑制 (検証通過しない POST は DB に到達しない)
+    # - blog_id の存在推測の防止 (Turnstile 失敗時は 404/422 の差が出ない)
+    # Cloudflare siteverify はレート制限が緩い (Free 100万/日) ため、
+    # 存在しない blog_id で 1 回外部 API を叩くコストは許容できる。
     before_action :verify_turnstile!, only: [:create]
+    before_action :set_blog
     before_action :set_cdn_cacheable, only: [:index]
 
     # GET /api/blogs/:blog_id/comments

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -3,6 +3,7 @@
 module Api
   class CommentsController < ApplicationController
     before_action :set_blog
+    before_action :verify_turnstile!, only: [:create]
     before_action :set_cdn_cacheable, only: [:index]
 
     # GET /api/blogs/:blog_id/comments
@@ -54,6 +55,17 @@ module Api
 
     def comment_params
       params.require(:comment).permit(:user_name, :comment)
+    end
+
+    # Cloudflare Turnstile token を検証して bot / spam を弾く。
+    # token は body の top-level に `turnstile_token` として渡される想定:
+    #   { "comment": { "user_name": "...", "comment": "..." }, "turnstile_token": "..." }
+    # 不正・失効・未送信のいずれも 422 で同じレスポンスを返す
+    # (個別のエラー差分から検証ロジックを推測されないようにする)。
+    def verify_turnstile!
+      return if TurnstileService.verify(params[:turnstile_token], remote_ip: request.remote_ip)
+
+      render json: { errors: ['認証に失敗しました。再度お試しください。'] }, status: :unprocessable_entity
     end
   end
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -63,9 +63,18 @@ module Api
     # 不正・失効・未送信のいずれも 422 で同じレスポンスを返す
     # (個別のエラー差分から検証ロジックを推測されないようにする)。
     def verify_turnstile!
-      return if TurnstileService.verify(params[:turnstile_token], remote_ip: request.remote_ip)
+      return if TurnstileService.verify(params[:turnstile_token], remote_ip: safe_remote_ip)
 
       render json: { errors: ['認証に失敗しました。再度お試しください。'] }, status: :unprocessable_entity
+    end
+
+    # request.remote_ip は X-Forwarded-For の異常 (IpSpoofAttackError) で raise しうる。
+    # remote_ip は Turnstile では optional フィールドなので、取得失敗時は nil で続行し、
+    # 攻撃者の XFF 偽装による 500 量産を防ぐ (rack_attack.rb の client_ip と同じパターン)。
+    def safe_remote_ip
+      request.remote_ip
+    rescue StandardError
+      nil
     end
   end
 end

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -23,6 +23,11 @@ class TurnstileService
   SITEVERIFY_URL = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify').freeze
   TIMEOUT = 5
 
+  # Cloudflare Turnstile token のサイズ上限 (公式仕様 ~2048 chars)。
+  # 公開エンドポイント経由で過大な値を Cloudflare へ転送する増幅攻撃を防ぐため、
+  # 型と byte size を事前検証する。
+  MAX_TOKEN_BYTESIZE = 2048
+
   # ENV.fetch は未設定だけ弾くので blank? でガードしてからフリーズ
   # (空文字 "TURNSTILE_SECRET_KEY=" で渡された場合に boot 時に気付くため)。
   SECRET_KEY = ENV.fetch('TURNSTILE_SECRET_KEY').tap do |value|
@@ -40,14 +45,19 @@ class TurnstileService
   # @param remote_ip [String, nil] 検証対象のクライアント IP (任意・推奨)
   # @return [Boolean]
   def self.verify(token, remote_ip: nil)
-    return false if token.blank?
+    return false unless token.is_a?(String)
+    return false if token.blank? || token.bytesize > MAX_TOKEN_BYTESIZE
 
     response = post_siteverify(token, remote_ip)
     return false unless response.is_a?(Net::HTTPSuccess)
 
     result = JSON.parse(response.body)
     return false unless result['success'] == true
-    return true if ALLOWED_HOSTNAMES.empty?
+    # ALLOWED_HOSTNAMES 未設定の扱い:
+    # - dev / test: スキップ (true) して動かす
+    # - production: fail-closed (false) にして設定ミスを検知させる
+    #   (silent に hostname 検証が無効化される事故を防ぐため)
+    return !Rails.env.production? if ALLOWED_HOSTNAMES.empty?
 
     ALLOWED_HOSTNAMES.include?(result['hostname'])
   rescue StandardError => e

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -57,25 +57,34 @@ class TurnstileService
 
   SECRET_KEY = ENV.fetch('TURNSTILE_SECRET_KEY').tap { |value| validate_secret_key!(value) }.freeze
 
-  # 本番環境で TURNSTILE_ALLOWED_HOSTNAMES が空なら boot 時に raise する。
-  # 設定漏れの silent な hostname 検証無効化を防ぎ、デプロイ時の CrashLoopBackOff
-  # で即異常検知できるようにする (SECRET_KEY と同じ fail-fast パターン)。
-  # テスト可能にするため private class method として切り出している。
-  def self.validate_allowed_hostnames!(raw_value)
-    return unless Rails.env.production? && raw_value.blank?
+  # カンマ区切りの ENV 値をパースして hostname の配列へ正規化する。
+  # 各要素を strip + 空要素除去するので、',', ' , ', 'a, ,b' などのような
+  # 部分的に空白を含む値も意図通りの空配列 / 有効な配列になる。
+  def self.parse_allowed_hostnames(raw_value)
+    raw_value.to_s.split(',').map(&:strip).reject(&:blank?)
+  end
+  private_class_method :parse_allowed_hostnames
+
+  # 本番環境で TURNSTILE_ALLOWED_HOSTNAMES が実質的に空 (空文字 / カンマだけ /
+  # 空白だけ) なら boot 時に raise する。設定漏れによる silent な hostname
+  # 検証無効化を防ぎ、デプロイ時の CrashLoopBackOff で即異常検知できるようにする
+  # (SECRET_KEY と同じ fail-fast パターン)。
+  # parse 後の Array に対して検証するため、',' のような値も確実に弾ける。
+  def self.validate_allowed_hostnames!(hostnames)
+    return unless Rails.env.production? && hostnames.empty?
 
     raise 'TURNSTILE_ALLOWED_HOSTNAMES must not be blank in production'
   end
   private_class_method :validate_allowed_hostnames!
 
-  # siteverify 応答の `hostname` を照合する allow-list (カンマ区切り)。
+  # siteverify 応答の `hostname` を照合する allow-list。
   # Cloudflare 側で site key は domain に紐付くため一次防御は済んでいるが、
   # site key 漏洩 + 別ホストへの差し替えなどの edge case に備えた多層防御。
-  # 未設定 (空 list) の場合は dev / test に限定 (本番は上記 fail-fast で除外)。
+  # 未設定 (空 list) は dev / test に限定 (本番は上記 fail-fast で除外)。
   raw_allowed_hostnames = ENV.fetch('TURNSTILE_ALLOWED_HOSTNAMES', '')
-  validate_allowed_hostnames!(raw_allowed_hostnames)
-  ALLOWED_HOSTNAMES = raw_allowed_hostnames
-                        .split(',').map(&:strip).reject(&:blank?).freeze
+  parsed_allowed_hostnames = parse_allowed_hostnames(raw_allowed_hostnames)
+  validate_allowed_hostnames!(parsed_allowed_hostnames)
+  ALLOWED_HOSTNAMES = parsed_allowed_hostnames.freeze
 
   # @param token [String, nil] フォームから submit された Turnstile token
   # @param remote_ip [String, nil] 検証対象のクライアント IP (任意・推奨)

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -29,6 +29,13 @@ class TurnstileService
     raise 'TURNSTILE_SECRET_KEY must not be blank' if value.blank?
   end.freeze
 
+  # siteverify 応答の `hostname` を照合する allow-list (カンマ区切り)。
+  # Cloudflare 側で site key は domain に紐付くため一次防御は済んでいるが、
+  # site key 漏洩 + 別ホストへの差し替えなどの edge case に備えた多層防御。
+  # 未設定 (空 list) の場合はチェックをスキップする (dev / test 用途)。
+  ALLOWED_HOSTNAMES = ENV.fetch('TURNSTILE_ALLOWED_HOSTNAMES', '')
+                        .split(',').map(&:strip).reject(&:blank?).freeze
+
   # @param token [String, nil] フォームから submit された Turnstile token
   # @param remote_ip [String, nil] 検証対象のクライアント IP (任意・推奨)
   # @return [Boolean]
@@ -38,7 +45,11 @@ class TurnstileService
     response = post_siteverify(token, remote_ip)
     return false unless response.is_a?(Net::HTTPSuccess)
 
-    JSON.parse(response.body)['success'] == true
+    result = JSON.parse(response.body)
+    return false unless result['success'] == true
+    return true if ALLOWED_HOSTNAMES.empty?
+
+    ALLOWED_HOSTNAMES.include?(result['hostname'])
   rescue StandardError => e
     Rails.logger.warn "TurnstileService: verify failed: #{e.message}"
     false

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -34,11 +34,24 @@ class TurnstileService
     raise 'TURNSTILE_SECRET_KEY must not be blank' if value.blank?
   end.freeze
 
+  # 本番環境で TURNSTILE_ALLOWED_HOSTNAMES が空なら boot 時に raise する。
+  # 設定漏れの silent な hostname 検証無効化を防ぎ、デプロイ時の CrashLoopBackOff
+  # で即異常検知できるようにする (SECRET_KEY と同じ fail-fast パターン)。
+  # テスト可能にするため private class method として切り出している。
+  def self.validate_allowed_hostnames!(raw_value)
+    return unless Rails.env.production? && raw_value.blank?
+
+    raise 'TURNSTILE_ALLOWED_HOSTNAMES must not be blank in production'
+  end
+  private_class_method :validate_allowed_hostnames!
+
   # siteverify 応答の `hostname` を照合する allow-list (カンマ区切り)。
   # Cloudflare 側で site key は domain に紐付くため一次防御は済んでいるが、
   # site key 漏洩 + 別ホストへの差し替えなどの edge case に備えた多層防御。
-  # 未設定 (空 list) の場合はチェックをスキップする (dev / test 用途)。
-  ALLOWED_HOSTNAMES = ENV.fetch('TURNSTILE_ALLOWED_HOSTNAMES', '')
+  # 未設定 (空 list) の場合は dev / test に限定 (本番は上記 fail-fast で除外)。
+  raw_allowed_hostnames = ENV.fetch('TURNSTILE_ALLOWED_HOSTNAMES', '')
+  validate_allowed_hostnames!(raw_allowed_hostnames)
+  ALLOWED_HOSTNAMES = raw_allowed_hostnames
                         .split(',').map(&:strip).reject(&:blank?).freeze
 
   # @param token [String, nil] フォームから submit された Turnstile token
@@ -53,11 +66,9 @@ class TurnstileService
 
     result = JSON.parse(response.body)
     return false unless result['success'] == true
-    # ALLOWED_HOSTNAMES 未設定の扱い:
-    # - dev / test: スキップ (true) して動かす
-    # - production: fail-closed (false) にして設定ミスを検知させる
-    #   (silent に hostname 検証が無効化される事故を防ぐため)
-    return !Rails.env.production? if ALLOWED_HOSTNAMES.empty?
+    # ALLOWED_HOSTNAMES が空なのは dev / test に限られる (本番は boot 時 fail-fast)。
+    # その場合は hostname を見ずに success のみで判定する。
+    return true if ALLOWED_HOSTNAMES.empty?
 
     ALLOWED_HOSTNAMES.include?(result['hostname'])
   rescue StandardError => e

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+# Cloudflare Turnstile token verifier.
+# コメントフォームから送られた token を Cloudflare の siteverify API で検証し、
+# bot / spam を k8s 到達前にフィルタする目的。
+#
+# 設計方針:
+# - SECRET_KEY をクラス読み込み時に必須化することで、デプロイ時の設定漏れを
+#   起動時に fail-fast で検知する (silent failure を防ぐため)。
+# - 例外時は false を返して fail-closed (検証できない以上は弾く)。
+# - dev / test 環境では Cloudflare 公開のテストキーを利用する
+#   (always pass: 1x0000000000000000000000000000000AA)。
+class TurnstileService
+  SITEVERIFY_URL = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify').freeze
+  TIMEOUT = 5
+
+  # ENV.fetch は未設定だけ弾くので blank? でガードしてからフリーズ
+  # (空文字 "TURNSTILE_SECRET_KEY=" で渡された場合に boot 時に気付くため)。
+  SECRET_KEY = ENV.fetch('TURNSTILE_SECRET_KEY').tap do |value|
+    raise 'TURNSTILE_SECRET_KEY must not be blank' if value.blank?
+  end.freeze
+
+  # @param token [String, nil] フォームから submit された Turnstile token
+  # @param remote_ip [String, nil] 検証対象のクライアント IP (任意・推奨)
+  # @return [Boolean]
+  def self.verify(token, remote_ip: nil)
+    return false if token.blank?
+
+    response = post_siteverify(token, remote_ip)
+    return false unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)['success'] == true
+  rescue StandardError => e
+    Rails.logger.warn "TurnstileService: verify failed: #{e.message}"
+    false
+  end
+
+  def self.post_siteverify(token, remote_ip)
+    params = { secret: SECRET_KEY, response: token }
+    params[:remoteip] = remote_ip if remote_ip.present?
+
+    http = Net::HTTP.new(SITEVERIFY_URL.host, SITEVERIFY_URL.port)
+    http.use_ssl = true
+    http.open_timeout = TIMEOUT
+    http.read_timeout = TIMEOUT
+
+    request = Net::HTTP::Post.new(SITEVERIFY_URL.request_uri)
+    request.set_form_data(params)
+    http.request(request)
+  end
+  private_class_method :post_siteverify
+end

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -9,11 +9,16 @@ require 'uri'
 # bot / spam を k8s 到達前にフィルタする目的。
 #
 # 設計方針:
-# - SECRET_KEY をクラス読み込み時に必須化することで、デプロイ時の設定漏れを
-#   起動時に fail-fast で検知する (silent failure を防ぐため)。
+# - SECRET_KEY をクラス読み込み時に ENV.fetch で必須化することで、
+#   デプロイ時の設定漏れを起動時に fail-fast で検知する (silent failure を防ぐため)。
+#   この仕様は全環境共通で、未設定なら起動失敗 (環境分岐は意図的に持たせない)。
 # - 例外時は false を返して fail-closed (検証できない以上は弾く)。
-# - dev / test 環境では Cloudflare 公開のテストキーを利用する
-#   (always pass: 1x0000000000000000000000000000000AA)。
+#
+# 環境別の TURNSTILE_SECRET_KEY 注入経路 (コード外で別途設定):
+# - production: app-secrets Secret (Drone CI が SSM 経由で kubectl apply)
+# - development: docker-compose.yml で Cloudflare 公開テストキーを env として注入
+#                (1x0000000000000000000000000000000AA, always pass)
+# - test: spec/rails_helper.rb で `ENV[...] ||= 'test-turnstile-secret'`
 class TurnstileService
   SITEVERIFY_URL = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify').freeze
   TIMEOUT = 5

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -47,6 +47,7 @@ class TurnstileService
     http.use_ssl = true
     http.open_timeout = TIMEOUT
     http.read_timeout = TIMEOUT
+    http.write_timeout = TIMEOUT
 
     request = Net::HTTP::Post.new(SITEVERIFY_URL.request_uri)
     request.set_form_data(params)

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -28,11 +28,34 @@ class TurnstileService
   # 型と byte size を事前検証する。
   MAX_TOKEN_BYTESIZE = 2048
 
-  # ENV.fetch は未設定だけ弾くので blank? でガードしてからフリーズ
-  # (空文字 "TURNSTILE_SECRET_KEY=" で渡された場合に boot 時に気付くため)。
-  SECRET_KEY = ENV.fetch('TURNSTILE_SECRET_KEY').tap do |value|
+  # Cloudflare が公開しているテスト用 secret key (公式ドキュメントに掲載)。
+  #   1x...AA: 常に検証成功 (dev / test の標準キー)
+  #   2x...AA: 常に検証失敗 (失敗シナリオの確認用)
+  #   3x...FF: 常に spent-token エラー (再利用シナリオの確認用)
+  # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+  # docker-compose.yml に always-pass の値が直書きされている関係上、
+  # 設定ミスで本番にコピペされる可能性が現実的にあるため、
+  # boot 時に本番デプロイを fail-fast で弾く。
+  PUBLIC_TEST_SECRET_KEYS = %w[
+    1x0000000000000000000000000000000AA
+    2x0000000000000000000000000000000AA
+    3x0000000000000000000000000000000FF
+  ].freeze
+
+  # SECRET_KEY 検証 (boot-time fail-fast)。
+  # - 空文字 / 未設定: 全環境共通で raise (silent failure 防止)
+  # - 本番 + Cloudflare 公開テストキー: raise (誤デプロイで Turnstile 検証が
+  #   実質バイパスされる事故を防ぐ)
+  # テスト可能にするため private class method として切り出している。
+  def self.validate_secret_key!(value)
     raise 'TURNSTILE_SECRET_KEY must not be blank' if value.blank?
-  end.freeze
+    return unless Rails.env.production? && PUBLIC_TEST_SECRET_KEYS.include?(value)
+
+    raise 'TURNSTILE_SECRET_KEY must not be a public test key in production'
+  end
+  private_class_method :validate_secret_key!
+
+  SECRET_KEY = ENV.fetch('TURNSTILE_SECRET_KEY').tap { |value| validate_secret_key!(value) }.freeze
 
   # 本番環境で TURNSTILE_ALLOWED_HOSTNAMES が空なら boot 時に raise する。
   # 設定漏れの silent な hostname 検証無効化を防ぎ、デプロイ時の CrashLoopBackOff

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,11 @@ services:
       - DATABASE_HOST=db
       - DATABASE_USERNAME=postgres
       - DATABASE_PASSWORD=password
+      # Cloudflare 公開のテストキー (always pass)。
+      # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+      # 本物の Site Key と組み合わせて使うとフロント側で常に検証成功する。
+      # 開発時にコメント投稿が動作することを優先するため直書きしている (公開値)。
+      - TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 
 volumes:
   tmp:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ ENV['RAILS_ENV'] ||= 'test'
 # クラス読み込み時に ENV.fetch される必須環境変数のテスト用デフォルト。
 # 未設定だと PasswordsController のクラス定数評価で KeyError が出てテスト全体が起動失敗する。
 ENV['PASSWORD_RESET_SECRET'] ||= 'test-password-reset-secret'
+ENV['TURNSTILE_SECRET_KEY'] ||= 'test-turnstile-secret'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?

--- a/spec/requests/api/blogs/comments_spec.rb
+++ b/spec/requests/api/blogs/comments_spec.rb
@@ -83,6 +83,30 @@ RSpec.describe 'Api::Blogs::Comments', type: :request do
       end
     end
 
+    # request.remote_ip は XFF 偽装などで raise しうる (IpSpoofAttackError)。
+    # safe_remote_ip ヘルパーが nil フォールバックする挙動を、コントローラ単体で検証する。
+    # request spec で and_raise すると Rails::Rack::Logger も remote_ip を呼ぶため
+    # middleware 段階で 500 になってしまい、コントローラ層の挙動を分離できない。
+    describe '#safe_remote_ip (private)' do
+      it 'request.remote_ip が StandardError を raise したら nil を返すこと' do
+        controller = Api::CommentsController.new
+        fake_request = instance_double(ActionDispatch::Request)
+        allow(fake_request).to receive(:remote_ip)
+          .and_raise(ActionDispatch::RemoteIp::IpSpoofAttackError, 'spoofed')
+        allow(controller).to receive(:request).and_return(fake_request)
+
+        expect(controller.send(:safe_remote_ip)).to be_nil
+      end
+
+      it '通常時は request.remote_ip の値を返すこと' do
+        controller = Api::CommentsController.new
+        fake_request = instance_double(ActionDispatch::Request, remote_ip: '203.0.113.10')
+        allow(controller).to receive(:request).and_return(fake_request)
+
+        expect(controller.send(:safe_remote_ip)).to eq('203.0.113.10')
+      end
+    end
+
     context 'Blog が存在しない場合' do
       before { allow(TurnstileService).to receive(:verify).and_return(true) }
 

--- a/spec/requests/api/blogs/comments_spec.rb
+++ b/spec/requests/api/blogs/comments_spec.rb
@@ -66,6 +66,23 @@ RSpec.describe 'Api::Blogs::Comments', type: :request do
       end
     end
 
+    context 'Turnstile 検証が成功したがコメントが無効な場合' do
+      before { allow(TurnstileService).to receive(:verify).and_return(true) }
+
+      it 'コメントを作成せず comment の errors を含む 422 を返すこと' do
+        expect do
+          post "/api/blogs/#{blog.id}/comments",
+               params: { comment: { user_name: '', comment: 'body' }, turnstile_token: 'good-token' }.to_json,
+               headers: headers
+        end.not_to change(Comment, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).not_to be_empty
+        # 認証エラーメッセージではないこと (Turnstile 通過後の comment validation エラー)
+        expect(response.parsed_body['errors']).not_to include('認証に失敗しました。再度お試しください。')
+      end
+    end
+
     context 'Blog が存在しない場合' do
       before { allow(TurnstileService).to receive(:verify).and_return(true) }
 

--- a/spec/requests/api/blogs/comments_spec.rb
+++ b/spec/requests/api/blogs/comments_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::Blogs::Comments', type: :request do
+  let(:blog) { create(:blog) }
+  let(:headers) { { 'Content-Type' => 'application/json' } }
+  let(:valid_comment_params) { { user_name: 'taro', comment: 'good post!' } }
+
+  describe 'POST /api/blogs/:blog_id/comments' do
+    context 'Turnstile 検証が成功した場合' do
+      before { allow(TurnstileService).to receive(:verify).and_return(true) }
+
+      it 'コメントを作成して 201 を返すこと' do
+        expect do
+          post "/api/blogs/#{blog.id}/comments",
+               params: { comment: valid_comment_params, turnstile_token: 'good-token' }.to_json,
+               headers: headers
+        end.to change(Comment, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body['user_name']).to eq('taro')
+        expect(body['comment']).to eq('good post!')
+      end
+
+      it 'Turnstile.verify に token と remote_ip を渡すこと' do
+        expect(TurnstileService).to receive(:verify)
+          .with('good-token', remote_ip: kind_of(String))
+          .and_return(true)
+
+        post "/api/blogs/#{blog.id}/comments",
+             params: { comment: valid_comment_params, turnstile_token: 'good-token' }.to_json,
+             headers: headers
+      end
+    end
+
+    context 'Turnstile 検証が失敗した場合' do
+      before { allow(TurnstileService).to receive(:verify).and_return(false) }
+
+      it 'コメントを作成せず 422 を返すこと' do
+        expect do
+          post "/api/blogs/#{blog.id}/comments",
+               params: { comment: valid_comment_params, turnstile_token: 'bad-token' }.to_json,
+               headers: headers
+        end.not_to change(Comment, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('認証に失敗しました。再度お試しください。')
+      end
+
+      it 'token が空でも 422 を返すこと' do
+        post "/api/blogs/#{blog.id}/comments",
+             params: { comment: valid_comment_params, turnstile_token: '' }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'token が未送信でも 422 を返すこと' do
+        post "/api/blogs/#{blog.id}/comments",
+             params: { comment: valid_comment_params }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'Blog が存在しない場合' do
+      before { allow(TurnstileService).to receive(:verify).and_return(true) }
+
+      it '404 を返すこと' do
+        post '/api/blogs/0/comments',
+             params: { comment: valid_comment_params, turnstile_token: 'good-token' }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/services/turnstile_service_spec.rb
+++ b/spec/services/turnstile_service_spec.rb
@@ -27,12 +27,44 @@ RSpec.describe TurnstileService do
     end
 
     context 'siteverify が success: true を返した場合' do
-      it 'true を返すこと' do
+      it 'ALLOWED_HOSTNAMES が空なら hostname を見ずに true を返すこと' do
         http = instance_double(Net::HTTP)
         stub_http(http)
         stub_request_returning(http, make_response('200', body: { success: true }.to_json))
 
         expect(described_class.verify(token, remote_ip: remote_ip)).to be true
+      end
+    end
+
+    context 'ALLOWED_HOSTNAMES が設定されている場合' do
+      it 'hostname が allow list に含まれていれば true を返すこと' do
+        stub_const('TurnstileService::ALLOWED_HOSTNAMES', %w[go-lilaregard.com www.go-lilaregard.com])
+
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: { success: true, hostname: 'go-lilaregard.com' }.to_json))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be true
+      end
+
+      it 'hostname が allow list に含まれていなければ false を返すこと (fail-closed)' do
+        stub_const('TurnstileService::ALLOWED_HOSTNAMES', %w[go-lilaregard.com])
+
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: { success: true, hostname: 'evil.example.com' }.to_json))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+
+      it 'hostname がレスポンスに含まれていなければ false を返すこと (fail-closed)' do
+        stub_const('TurnstileService::ALLOWED_HOSTNAMES', %w[go-lilaregard.com])
+
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: { success: true }.to_json))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
       end
     end
 

--- a/spec/services/turnstile_service_spec.rb
+++ b/spec/services/turnstile_service_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TurnstileService do
+  describe '.verify' do
+    let(:token) { 'dummy-token' }
+    let(:remote_ip) { '203.0.113.10' }
+
+    # Net::HTTP のレスポンスを差し替えるヘルパー (image_downloader_spec.rb と同じ方針)
+    def stub_http(http_double)
+      allow(Net::HTTP).to receive(:new).and_return(http_double)
+      allow(http_double).to receive(:use_ssl=)
+      allow(http_double).to receive(:open_timeout=)
+      allow(http_double).to receive(:read_timeout=)
+    end
+
+    def stub_request_returning(http, response)
+      allow(http).to receive(:request).and_return(response)
+    end
+
+    def make_response(code, body:)
+      response = Net::HTTPResponse::CODE_TO_OBJ[code].new('1.1', code, 'OK')
+      allow(response).to receive(:body).and_return(body)
+      response
+    end
+
+    context 'siteverify が success: true を返した場合' do
+      it 'true を返すこと' do
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: { success: true }.to_json))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be true
+      end
+    end
+
+    context 'siteverify が success: false を返した場合' do
+      it 'false を返すこと' do
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: { success: false, 'error-codes': ['invalid-input-response'] }.to_json))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+    end
+
+    context 'token が空文字の場合' do
+      it 'HTTP を叩かずに false を返すこと' do
+        expect(Net::HTTP).not_to receive(:new)
+        expect(described_class.verify('', remote_ip: remote_ip)).to be false
+      end
+    end
+
+    context 'token が nil の場合' do
+      it 'HTTP を叩かずに false を返すこと' do
+        expect(Net::HTTP).not_to receive(:new)
+        expect(described_class.verify(nil, remote_ip: remote_ip)).to be false
+      end
+    end
+
+    context 'siteverify が HTTP エラー (500) を返した場合' do
+      it 'false を返すこと (fail-closed)' do
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('500', body: ''))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+    end
+
+    context 'siteverify が timeout した場合' do
+      it 'false を返すこと (fail-closed)' do
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        allow(http).to receive(:request).and_raise(Net::OpenTimeout)
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+    end
+
+    context 'siteverify が不正な JSON を返した場合' do
+      it 'false を返すこと (fail-closed)' do
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: '<html>not json</html>'))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+    end
+  end
+end

--- a/spec/services/turnstile_service_spec.rb
+++ b/spec/services/turnstile_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe TurnstileService do
       allow(http_double).to receive(:use_ssl=)
       allow(http_double).to receive(:open_timeout=)
       allow(http_double).to receive(:read_timeout=)
+      allow(http_double).to receive(:write_timeout=)
     end
 
     def stub_request_returning(http, response)
@@ -70,10 +71,21 @@ RSpec.describe TurnstileService do
     end
 
     context 'siteverify が timeout した場合' do
-      it 'false を返すこと (fail-closed)' do
+      it 'Net::OpenTimeout でも false を返すこと (fail-closed)' do
         http = instance_double(Net::HTTP)
         stub_http(http)
         allow(http).to receive(:request).and_raise(Net::OpenTimeout)
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+
+      # Net::ReadTimeout は Ruby 3.2+ では Timeout::Error < RuntimeError < StandardError なので
+      # rescue StandardError で捕捉される。古い Ruby (< 3.1) では別系統だったため、
+      # Ruby アップグレードでの回帰を防ぐ目的で明示的にテストする。
+      it 'Net::ReadTimeout でも false を返すこと (fail-closed)' do
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        allow(http).to receive(:request).and_raise(Net::ReadTimeout)
 
         expect(described_class.verify(token, remote_ip: remote_ip)).to be false
       end

--- a/spec/services/turnstile_service_spec.rb
+++ b/spec/services/turnstile_service_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe TurnstileService do
       end
     end
 
+    context 'ALLOWED_HOSTNAMES が空 (未設定) で本番環境の場合' do
+      before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+      it 'success: true でも false を返すこと (fail-closed)' do
+        stub_const('TurnstileService::ALLOWED_HOSTNAMES', [].freeze)
+
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: { success: true, hostname: 'go-lilaregard.com' }.to_json))
+
+        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+    end
+
     context 'ALLOWED_HOSTNAMES が設定されている場合' do
       it 'hostname が allow list に含まれていれば true を返すこと' do
         stub_const('TurnstileService::ALLOWED_HOSTNAMES', %w[go-lilaregard.com www.go-lilaregard.com])
@@ -89,6 +103,32 @@ RSpec.describe TurnstileService do
       it 'HTTP を叩かずに false を返すこと' do
         expect(Net::HTTP).not_to receive(:new)
         expect(described_class.verify(nil, remote_ip: remote_ip)).to be false
+      end
+    end
+
+    context 'token が String 以外の場合 (Hash, Array, Integer 等)' do
+      it 'HTTP を叩かずに false を返すこと (型攻撃の防御)' do
+        expect(Net::HTTP).not_to receive(:new)
+        expect(described_class.verify({ nested: 'value' }, remote_ip: remote_ip)).to be false
+        expect(described_class.verify(['x'], remote_ip: remote_ip)).to be false
+        expect(described_class.verify(123, remote_ip: remote_ip)).to be false
+      end
+    end
+
+    context 'token が MAX_TOKEN_BYTESIZE を超える場合' do
+      it 'HTTP を叩かずに false を返すこと (増幅攻撃の防御)' do
+        oversized = 'a' * (TurnstileService::MAX_TOKEN_BYTESIZE + 1)
+        expect(Net::HTTP).not_to receive(:new)
+        expect(described_class.verify(oversized, remote_ip: remote_ip)).to be false
+      end
+
+      it 'ちょうど MAX_TOKEN_BYTESIZE バイトなら HTTP を叩くこと (境界値)' do
+        exact = 'a' * TurnstileService::MAX_TOKEN_BYTESIZE
+        http = instance_double(Net::HTTP)
+        stub_http(http)
+        stub_request_returning(http, make_response('200', body: { success: true }.to_json))
+
+        expect(described_class.verify(exact, remote_ip: remote_ip)).to be true
       end
     end
 

--- a/spec/services/turnstile_service_spec.rb
+++ b/spec/services/turnstile_service_spec.rb
@@ -165,8 +165,14 @@ RSpec.describe TurnstileService do
   # として切り出してあるので、メソッド単体で挙動を確認する。
   describe '.validate_secret_key! (boot-time fail-fast)' do
     context 'ENV が空文字の場合' do
-      it '全環境共通で blank の旨を raise すること' do
+      it '本番環境でも blank の旨を raise すること' do
         allow(Rails.env).to receive(:production?).and_return(true)
+        expect { described_class.send(:validate_secret_key!, '') }
+          .to raise_error(RuntimeError, /TURNSTILE_SECRET_KEY must not be blank/)
+      end
+
+      it '非本番でも blank の旨を raise すること (全環境共通)' do
+        allow(Rails.env).to receive(:production?).and_return(false)
         expect { described_class.send(:validate_secret_key!, '') }
           .to raise_error(RuntimeError, /TURNSTILE_SECRET_KEY must not be blank/)
       end
@@ -206,20 +212,63 @@ RSpec.describe TurnstileService do
     end
   end
 
+  # ENV 値のパース挙動を検証する。
+  # ',' や ' , ' のような空 hostname しか含まない値が parse 後に空配列に
+  # 正規化されることが、validate_allowed_hostnames! の fail-fast の前提となる
+  # (raw_value.blank? では弾けない実質空ケースを confirm)。
+  describe '.parse_allowed_hostnames' do
+    it 'カンマ区切りで配列にすること' do
+      expect(described_class.send(:parse_allowed_hostnames, 'a.example.com,b.example.com'))
+        .to eq(%w[a.example.com b.example.com])
+    end
+
+    it '各要素を strip し、空白を除去すること' do
+      expect(described_class.send(:parse_allowed_hostnames, ' a.example.com , b.example.com '))
+        .to eq(%w[a.example.com b.example.com])
+    end
+
+    it '空要素を除去すること (a, ,b → [a, b])' do
+      expect(described_class.send(:parse_allowed_hostnames, 'a.example.com, ,b.example.com'))
+        .to eq(%w[a.example.com b.example.com])
+    end
+
+    it '空文字 → 空配列' do
+      expect(described_class.send(:parse_allowed_hostnames, '')).to eq([])
+    end
+
+    it 'カンマだけ → 空配列' do
+      expect(described_class.send(:parse_allowed_hostnames, ',')).to eq([])
+    end
+
+    it 'カンマと空白だけ → 空配列' do
+      expect(described_class.send(:parse_allowed_hostnames, ' , , ')).to eq([])
+    end
+
+    it 'nil → 空配列 (to_s 経由で安全に変換)' do
+      expect(described_class.send(:parse_allowed_hostnames, nil)).to eq([])
+    end
+  end
+
   # boot 時の TURNSTILE_ALLOWED_HOSTNAMES 必須化を検証する。
   # 実体は class 読み込み時に走るが、validate_allowed_hostnames! を private class method
   # として切り出してあるので、メソッド単体で挙動を確認する。
+  # 引数は parse_allowed_hostnames 経由で正規化済みの Array<String> を渡す。
   describe '.validate_allowed_hostnames! (boot-time fail-fast)' do
-    context '本番環境かつ ENV が空文字の場合' do
+    context '本番環境かつ正規化後が空配列の場合' do
       before { allow(Rails.env).to receive(:production?).and_return(true) }
 
-      it '設定漏れを検知して raise すること' do
-        expect { described_class.send(:validate_allowed_hostnames!, '') }
+      it '空配列 ([]) → raise (純粋な空文字 ENV)' do
+        expect { described_class.send(:validate_allowed_hostnames!, []) }
           .to raise_error(RuntimeError, /TURNSTILE_ALLOWED_HOSTNAMES must not be blank in production/)
       end
 
-      it '空白だけの値も raise すること' do
-        expect { described_class.send(:validate_allowed_hostnames!, '  ') }
+      # parse_allowed_hostnames が ',' や ' , ' を [] に正規化することで、
+      # bot 指摘の「raw.blank? を通過するが verify では実質バイパス」のケースが
+      # 確実に boot 時に止められることを確認する。
+      it "',' のような実質空の ENV も parse 後の空配列を経由して raise されること" do
+        parsed = described_class.send(:parse_allowed_hostnames, ',')
+        expect(parsed).to eq([])
+        expect { described_class.send(:validate_allowed_hostnames!, parsed) }
           .to raise_error(RuntimeError, /TURNSTILE_ALLOWED_HOSTNAMES must not be blank in production/)
       end
     end
@@ -228,16 +277,16 @@ RSpec.describe TurnstileService do
       before { allow(Rails.env).to receive(:production?).and_return(true) }
 
       it 'raise しないこと' do
-        expect { described_class.send(:validate_allowed_hostnames!, 'go-lilaregard.com') }
+        expect { described_class.send(:validate_allowed_hostnames!, ['go-lilaregard.com']) }
           .not_to raise_error
       end
     end
 
-    context '本番環境以外で ENV が空の場合' do
+    context '本番環境以外で空配列の場合' do
       before { allow(Rails.env).to receive(:production?).and_return(false) }
 
       it 'raise しないこと (dev / test では空 list 許容)' do
-        expect { described_class.send(:validate_allowed_hostnames!, '') }
+        expect { described_class.send(:validate_allowed_hostnames!, []) }
           .not_to raise_error
       end
     end

--- a/spec/services/turnstile_service_spec.rb
+++ b/spec/services/turnstile_service_spec.rb
@@ -36,20 +36,6 @@ RSpec.describe TurnstileService do
       end
     end
 
-    context 'ALLOWED_HOSTNAMES が空 (未設定) で本番環境の場合' do
-      before { allow(Rails.env).to receive(:production?).and_return(true) }
-
-      it 'success: true でも false を返すこと (fail-closed)' do
-        stub_const('TurnstileService::ALLOWED_HOSTNAMES', [].freeze)
-
-        http = instance_double(Net::HTTP)
-        stub_http(http)
-        stub_request_returning(http, make_response('200', body: { success: true, hostname: 'go-lilaregard.com' }.to_json))
-
-        expect(described_class.verify(token, remote_ip: remote_ip)).to be false
-      end
-    end
-
     context 'ALLOWED_HOSTNAMES が設定されている場合' do
       it 'hostname が allow list に含まれていれば true を返すこと' do
         stub_const('TurnstileService::ALLOWED_HOSTNAMES', %w[go-lilaregard.com www.go-lilaregard.com])
@@ -170,6 +156,43 @@ RSpec.describe TurnstileService do
         stub_request_returning(http, make_response('200', body: '<html>not json</html>'))
 
         expect(described_class.verify(token, remote_ip: remote_ip)).to be false
+      end
+    end
+  end
+
+  # boot 時の TURNSTILE_ALLOWED_HOSTNAMES 必須化を検証する。
+  # 実体は class 読み込み時に走るが、validate_allowed_hostnames! を private class method
+  # として切り出してあるので、メソッド単体で挙動を確認する。
+  describe '.validate_allowed_hostnames! (boot-time fail-fast)' do
+    context '本番環境かつ ENV が空文字の場合' do
+      before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+      it '設定漏れを検知して raise すること' do
+        expect { described_class.send(:validate_allowed_hostnames!, '') }
+          .to raise_error(RuntimeError, /TURNSTILE_ALLOWED_HOSTNAMES must not be blank in production/)
+      end
+
+      it '空白だけの値も raise すること' do
+        expect { described_class.send(:validate_allowed_hostnames!, '  ') }
+          .to raise_error(RuntimeError, /TURNSTILE_ALLOWED_HOSTNAMES must not be blank in production/)
+      end
+    end
+
+    context '本番環境で値が設定されている場合' do
+      before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+      it 'raise しないこと' do
+        expect { described_class.send(:validate_allowed_hostnames!, 'go-lilaregard.com') }
+          .not_to raise_error
+      end
+    end
+
+    context '本番環境以外で ENV が空の場合' do
+      before { allow(Rails.env).to receive(:production?).and_return(false) }
+
+      it 'raise しないこと (dev / test では空 list 許容)' do
+        expect { described_class.send(:validate_allowed_hostnames!, '') }
+          .not_to raise_error
       end
     end
   end

--- a/spec/services/turnstile_service_spec.rb
+++ b/spec/services/turnstile_service_spec.rb
@@ -160,6 +160,52 @@ RSpec.describe TurnstileService do
     end
   end
 
+  # boot 時の SECRET_KEY 必須化と本番公開テストキー拒否を検証する。
+  # 実体は class 読み込み時に走るが、validate_secret_key! を private class method
+  # として切り出してあるので、メソッド単体で挙動を確認する。
+  describe '.validate_secret_key! (boot-time fail-fast)' do
+    context 'ENV が空文字の場合' do
+      it '全環境共通で blank の旨を raise すること' do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        expect { described_class.send(:validate_secret_key!, '') }
+          .to raise_error(RuntimeError, /TURNSTILE_SECRET_KEY must not be blank/)
+      end
+    end
+
+    context '本番環境で Cloudflare 公開テストキーが設定されている場合' do
+      before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+      it 'always-pass キーを raise すること' do
+        expect { described_class.send(:validate_secret_key!, '1x0000000000000000000000000000000AA') }
+          .to raise_error(RuntimeError, /must not be a public test key in production/)
+      end
+
+      it 'always-fail キーも raise すること' do
+        expect { described_class.send(:validate_secret_key!, '2x0000000000000000000000000000000AA') }
+          .to raise_error(RuntimeError, /must not be a public test key in production/)
+      end
+
+      it 'spent-token キーも raise すること' do
+        expect { described_class.send(:validate_secret_key!, '3x0000000000000000000000000000000FF') }
+          .to raise_error(RuntimeError, /must not be a public test key in production/)
+      end
+
+      it '本物の鍵 (テストキー以外) なら raise しないこと' do
+        expect { described_class.send(:validate_secret_key!, 'real-production-secret-xxxxxxxxxx') }
+          .not_to raise_error
+      end
+    end
+
+    context '非本番環境で Cloudflare 公開テストキーが設定されている場合' do
+      before { allow(Rails.env).to receive(:production?).and_return(false) }
+
+      it 'raise しないこと (dev / test で常用するキーのため)' do
+        expect { described_class.send(:validate_secret_key!, '1x0000000000000000000000000000000AA') }
+          .not_to raise_error
+      end
+    end
+  end
+
   # boot 時の TURNSTILE_ALLOWED_HOSTNAMES 必須化を検証する。
   # 実体は class 読み込み時に走るが、validate_allowed_hostnames! を private class method
   # として切り出してあるので、メソッド単体で挙動を確認する。


### PR DESCRIPTION
## Summary

myblog のコメント投稿 (`POST /api/blogs/:blog_id/comments`) で Cloudflare Turnstile の token 検証を行い、bot / spam を k8s 到達前にフィルタする。

- **新規**: `app/services/turnstile_service.rb` — Net::HTTP で siteverify を叩く verifier
- **修正**: `app/controllers/api/comments_controller.rb` — `verify_turnstile!` before_action
- **修正**: `docker-compose.yml` — dev 用に Cloudflare 公開のテストキー (always pass) を設定
- **修正**: `spec/rails_helper.rb` — test 環境用 default 値を 1 行追加
- **新規**: `spec/services/turnstile_service_spec.rb` (7 ケース)
- **新規**: `spec/requests/api/blogs/comments_spec.rb` (5 ケース)

## 設計

- `SECRET_KEY` をクラス読み込み時に `ENV.fetch` で必須化 (`PasswordsController` と同じ fail-fast パターン)
- 例外時は `false` で **fail-closed** (検証できない以上は弾く)
- token は body の top-level (`params[:turnstile_token]`)
- 失敗は 422 「認証に失敗しました」(個別差分から検証ロジックを推測されないよう一律)

## 動作仕様

| 入力 | レスポンス |
|---|---|
| 正常 token + 正常 comment | 201 Created |
| token 空 / 不正 / Turnstile API 障害 | 422 |
| token OK + comment validation NG | 422 (comment errors) |

## 同時 merge 必須

`ENV.fetch('TURNSTILE_SECRET_KEY')` を boot 時必須化しているため、ops PR と **同時 merge** が必要。
過去 (ops #234) で env 設定漏れにより backend Pod が CrashLoopBackOff になった前例があるためのルール。

- 対応する ops PR: **terumitt-dev/go-lilaregard-ops#242**

## Test plan

- [x] `rspec spec/services/turnstile_service_spec.rb spec/requests/api/blogs/comments_spec.rb` 全 13 ケース pass (ローカル / Rancher Desktop)
- [ ] CI 通過 (drone)
- [ ] ops PR #242 と同時 merge
- [ ] 本番 backend Pod が `Running 1/1` で起動
- [ ] frontend 反映後に `https://go-lilaregard.com` のコメントフォームから投稿 → CAPTCHA 通過 → 成功
- [ ] token 無しで `curl` 投稿 → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)