### PR TITLE
chore: migrate CI/CD from DinD to Kaniko (type: kubernetes)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,16 +2,23 @@
 # CI/CD Pipeline
 # =========================
 kind: pipeline
-type: docker
+type: kubernetes
 name: ci-cd
 
 trigger:
+  event: [push, pull_request]
   branch: [main, develop]
 
+node_selector:
+  node-role: drone
+tolerations:
+  - key: dedicated
+    value: drone
+    effect: NoSchedule
+
 steps:
-  - name: build-and-verify
-    image: docker:24-dind
-    privileged: true
+  - name: check-vars
+    image: alpine
     environment:
       AWS_REGION:
         from_secret: AWS_REGION
@@ -22,104 +29,51 @@ steps:
       ECR_REGISTRY:
         from_secret: ECR_REGISTRY
     commands:
-      - set -euo pipefail
-      - echo "🐳 Starting Docker daemon..."
-      - dockerd-entrypoint.sh &
+      - set -euxo pipefail
+      - '[ -n "$AWS_REGION" ]'
+      - '[ -n "$AWS_ACCESS_KEY_ID" ]'
+      - '[ -n "$AWS_SECRET_ACCESS_KEY" ]'
+      - '[ -n "$ECR_REGISTRY" ]'
+
+  - name: setup-ecr-auth
+    image: amazon/aws-cli:latest
+    when:
+      branch: [main]
+      event: [push]
+    environment:
+      AWS_REGION:
+        from_secret: AWS_REGION
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      ECR_REGISTRY:
+        from_secret: ECR_REGISTRY
+    commands:
+      - mkdir -p /drone/src/.docker
       - |
-        for i in $(seq 1 60); do
-          if docker info >/dev/null 2>&1; then break; fi
-          echo "Waiting for Docker..."
-          sleep 1
-          if [ "$i" -eq 60 ]; then echo "❌ Docker daemon failed to start"; exit 1; fi
-        done
+        ECR_TOKEN=$(aws ecr get-login-password --region "$AWS_REGION")
+        AUTH=$(printf 'AWS:%s' "$ECR_TOKEN" | base64 -w 0)
+        printf '{"auths":{"%s":{"auth":"%s"}}}' "$ECR_REGISTRY" "$AUTH" > /drone/src/.docker/config.json
+      - echo "ECR auth config written"
 
-      # === CI: ビルド & 検証 ===
-      - echo "🔨 Building Docker image..."
-      - docker build -f Dockerfile.prod -t go-lilaregard-backend:ci .
-      - echo "✅ Build succeeded"
-
-      - echo ""
-      - echo "📏 Image size check..."
-      - docker images go-lilaregard-backend:ci --format "   Size:{{.Size}}"
-      - echo ""
-
-      - echo "🏥 Container startup check..."
+  - name: build
+    image: gcr.io/kaniko-project/executor:debug
+    environment:
+      ECR_REGISTRY:
+        from_secret: ECR_REGISTRY
+    commands:
       - |
-        docker run -d --name backend-ci \
-          -e RAILS_ENV=production \
-          -e SECRET_KEY_BASE=ci_test_secret_key_base_dummy_value_for_testing \
-          -e DATABASE_HOST=localhost \
-          -e DATABASE_USERNAME=dummy \
-          -e DATABASE_PASSWORD=dummy \
-          -p 3000:3000 \
-          go-lilaregard-backend:ci \
-          bundle exec puma -C config/puma.rb
-
-        echo "   Waiting for container to start..."
-        for i in $(seq 1 30); do
-          if docker ps --filter name=backend-ci --format "{{.Status}}" | grep -q "Up"; then
-            break
-          fi
-          sleep 1
-          if [ "$i" -eq 30 ]; then
-            echo "❌ Container failed to start"
-            docker logs backend-ci 2>&1 | tail -30
-            exit 1
-          fi
-        done
-
-        echo "   Container status:"
-        docker ps --filter name=backend-ci --format "   {{.Status}}"
-        echo "✅ Container is running"
-
-      - echo ""
-      - echo "🌐 Health check..."
-      - |
-        if docker exec backend-ci wget -qO- http://localhost:3000/up >/dev/null 2>&1; then
-          echo "✅ Health check passed (/up endpoint responded)"
+        if [ "$DRONE_BRANCH" = "main" ] && [ "$DRONE_BUILD_EVENT" = "push" ]; then
+          /kaniko/executor \
+            --context=dir:///drone/src \
+            --dockerfile=/drone/src/Dockerfile.prod \
+            --docker-config=/drone/src/.docker \
+            --destination="$ECR_REGISTRY/go-lilaregard-backend:$DRONE_COMMIT_SHA" \
+            --destination="$ECR_REGISTRY/go-lilaregard-backend:latest"
         else
-          echo "⚠️ Health check skipped (DB not available, but container started successfully)"
-        fi
-
-      - echo ""
-      - echo "🧹 Cleanup..."
-      - docker stop backend-ci && docker rm backend-ci
-      - echo "✅ All CI checks passed"
-
-      # === CI: ECR認証メカニズムの事前検証 ===
-      # Alpineのaws-cliが壊れたケースなど、CDで初めて発覚する問題を
-      # CI時点で検出するためamazon/aws-cliコンテナの起動だけ確認する
-      # （AWS認証情報は使わない）
-      - echo "🔍 Verifying ECR auth mechanism (no credentials needed)..."
-      - docker run --rm amazon/aws-cli:latest --version
-      - echo "✅ aws-cli image is operational"
-
-      # === CD: ECR push (mainブランチのみ) ===
-      - |
-        if [ "${DRONE_BUILD_EVENT}" = "push" ] && [ "${DRONE_BRANCH}" = "main" ]; then
-          echo ""
-          echo "🔐 Logging in to ECR..."
-          # Alpineのaws-cliパッケージはlibexpat ABI mismatchで壊れているため、
-          # DinD内でamazon/aws-cliコンテナを起動してECRトークンを取得する
-          ECR_TOKEN=$(docker run --rm \
-            -e AWS_REGION=$AWS_REGION \
-            -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-            -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-            amazon/aws-cli:latest \
-            ecr get-login-password --region $AWS_REGION)
-          echo "$ECR_TOKEN" | docker login --username AWS --password-stdin $ECR_REGISTRY
-
-          echo "🏷️ Tagging image for ECR..."
-          docker tag go-lilaregard-backend:ci $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA}
-          docker tag go-lilaregard-backend:ci $ECR_REGISTRY/go-lilaregard-backend:latest
-
-          echo "🚀 Pushing to ECR..."
-          docker push $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA}
-          docker push $ECR_REGISTRY/go-lilaregard-backend:latest
-
-          echo "✅ Image pushed successfully"
-          echo "   → $ECR_REGISTRY/go-lilaregard-backend:${DRONE_COMMIT_SHA}"
-        else
-          echo ""
-          echo "⏭️ Skipping ECR push (branch: ${DRONE_BRANCH}, push only on main)"
+          /kaniko/executor \
+            --context=dir:///drone/src \
+            --dockerfile=/drone/src/Dockerfile.prod \
+            --no-push
         fi


### PR DESCRIPTION
## Summary

- `type: docker` (DinD + docker:24-dind) を `type: kubernetes` (Kaniko) へ移行
- `node_selector: node-role: drone` + tolerations で drone 専用ノードへ固定
- `check-vars` ステップで必須シークレットの存在確認
- `setup-ecr-auth` ステップ（main push のみ）で `/drone/src/.docker/config.json` に ECR 認証情報を書き込み
- `build` ステップで Kaniko ビルド。main push → ECR push (:SHA + :latest)、それ以外 → `--no-push`

## Migration notes

- DinD は特権コンテナ必須のため削除。Kaniko は unprivileged で動作
- コンテナ起動ヘルスチェック (`docker run` / `/up` 確認) は Kaniko では実行不可のため削除
  - ビルド自体が通れば Dockerfile のコンパイルエラーは検出できる
- ECR 認証: 旧来の `amazon/aws-cli` DinD 内コンテナ起動方式 → `amazon/aws-cli` ステップで `config.json` 書き込みに変更
  - libexpat ABI mismatch 回避も兼ねる

## Test plan

- [ ] PR 上の build ステップが `--no-push` で通過すること
- [ ] main へのマージ後に setup-ecr-auth + build が ECR push まで完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)