### PR TITLE
fix: replace --docker-config with DOCKER_CONFIG env var for Kaniko

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,13 +62,13 @@ steps:
     environment:
       ECR_REGISTRY:
         from_secret: ECR_REGISTRY
+      DOCKER_CONFIG: /drone/src/.docker
     commands:
       - |
         if [ "$DRONE_BRANCH" = "main" ] && [ "$DRONE_BUILD_EVENT" = "push" ]; then
           /kaniko/executor \
             --context=dir:///drone/src \
             --dockerfile=/drone/src/Dockerfile.prod \
-            --docker-config=/drone/src/.docker \
             --destination="$ECR_REGISTRY/go-lilaregard-backend:$DRONE_COMMIT_SHA" \
             --destination="$ECR_REGISTRY/go-lilaregard-backend:latest"
         else


### PR DESCRIPTION
## Summary

- `--docker-config` は kaniko executor に存在しないフラグだったため削除
- 代わりに `DOCKER_CONFIG: /drone/src/.docker` を環境変数として build ステップに追加
- Kaniko は `DOCKER_CONFIG` 環境変数を参照して `config.json` を探す

## Root cause

`go-containerregistry` ライブラリ（Kaniko が内部で使用）は Docker の標準的な認証解決ロジックに従い、`DOCKER_CONFIG` 環境変数が指すディレクトリの `config.json` を読む。フラグではなく環境変数で渡す必要があった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)